### PR TITLE
Add content to RSS

### DIFF
--- a/notes/scripts/build.py
+++ b/notes/scripts/build.py
@@ -174,7 +174,7 @@ def main():
         tags = tags_raw.split(",")
         tags_html = get_html_tags(tags)
 
-        post_data.append((out_file, title[1], title[2], post))
+        post_data.append((out_file, title[1], title[2], post, output))
         for tag in tags:
             if tag not in all_tags:
                 all_tags[tag] = []
@@ -197,12 +197,13 @@ def main():
             fw.write(fr.read())
 
     fg = FeedGenerator()
-    for url, title, date, post in reversed(post_data):
+    for url, title, date, post, content in reversed(post_data):
         fe = fg.add_entry()
         fe.id('http://notes.eatonphil.com/' + url)
         fe.title(title)
         fe.link(href='http://notes.eatonphil.com/' + url)
         fe.pubDate(datetime.strptime(date, '%B %d, %Y').replace(tzinfo=timezone.utc))
+        fe.content(content)
 
     fg.id('http://notes.eatonphil.com/')
     fg.link(href='http://notes.eatonphil.com/')


### PR DESCRIPTION
I personally like reading content in my RSS reader, and I realized that eatonphil.com doesn't provide the content on the RSS feed. This PR updates the deploy script to include content to the RSS feed.

I'm not sure whether this is intended or not - I couldn't found any monetization(ads) on the site so I'm making this PR, but if it was intended, feel free to not accept this PR. 

Or, if you would like the subscribe & get-in-touch links also appear on the content, you can request that too. (Currently only the post data appears, as that required the most minimal code change.)